### PR TITLE
Hay que quitar un apartado

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,7 @@
 - Watch series or movies
 
 ## Github team:
+
+Esto de aquí no es tu equipo, sino tu perfil. tienes que quitar este apartado.
  
  https://github.com/smarcam1102


### PR DESCRIPTION
El apartado **Github team** es para cuando tengas equipos de trabajo. Podrías poner el enlace a "Teams" que hay en el repositorio, pero es demasiado avanzado para este momento.